### PR TITLE
explicitly allow connections on port 3306

### DIFF
--- a/site-cookbooks/rax-drupal/recipes/firewall-mysql.rb
+++ b/site-cookbooks/rax-drupal/recipes/firewall-mysql.rb
@@ -38,6 +38,7 @@ when "debian"
     port node['mysql']['port'].to_i
     protocol :tcp
     interface node['rax']['mysql']['interface']
+    action :allow
   end
 else
   include_recipe "firewall"


### PR DESCRIPTION
The default action for the firewall_rule resource is now :reject,
so :allow has to be stated.