### PR TITLE
use `AllowOverride All` in Apache site config

### DIFF
--- a/site-cookbooks/rax-drupal/templates/default/drupal.conf.erb
+++ b/site-cookbooks/rax-drupal/templates/default/drupal.conf.erb
@@ -6,6 +6,7 @@
   <Directory <%= @params[:docroot] %>>
     Options FollowSymLinks
     Order allow,deny
+    AllowOverride All
     Allow from all
   </Directory>
 


### PR DESCRIPTION
`AllowOverride All` in the Apache directory configuration for the drupal
docroot allows extensions to modify apache behavior using .htaccess
files.